### PR TITLE
distplot correction

### DIFF
--- a/Labs/02 - Decision Trees and Linear Regression.ipynb
+++ b/Labs/02 - Decision Trees and Linear Regression.ipynb
@@ -984,7 +984,7 @@
    "metadata": {},
    "source": [
     "### ========== Question 2.11 ==========\n",
-    "Another way of assessing the performance of the model is to inspect the distribution of the errors. Make a histogram plot by using seaborn's `displot` function. This will also show an estimate of the underlying distribution.\n",
+    "Another way of assessing the performance of the model is to inspect the distribution of the errors. Make a histogram plot by using seaborn's `distplot` function. This will also show an estimate of the underlying distribution.\n",
     "\n",
     "Does it look like the errors are normally distributed? Would you trust the fit of the distribution on the graph? Explain why."
    ]
@@ -1052,7 +1052,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The version of seaborn we are required to use is 0.9.0.
'distplot' is deprecated in newer versions of seaborn and 'displot' has been introduced in its place.
However, 0.9.0 does not have 'displot' yet.
It is a small detail but I thought it might clear the confusion amongst some students as they are doing the lab.